### PR TITLE
Xdefi Wallet Context Provider

### DIFF
--- a/src/context/XDEFIProvider/XDEFIContext.ts
+++ b/src/context/XDEFIProvider/XDEFIContext.ts
@@ -1,0 +1,11 @@
+import { createContext } from 'react'
+
+import { ActionTypes } from './actions'
+import { InitialState } from './types'
+
+export interface IXDEFIProviderContext {
+  state: InitialState
+  dispatch: React.Dispatch<ActionTypes>
+}
+
+export const XDEFIProviderContext = createContext<IXDEFIProviderContext | null>(null)

--- a/src/context/XDEFIProvider/XDEFIWalletProvider.tsx
+++ b/src/context/XDEFIProvider/XDEFIWalletProvider.tsx
@@ -1,0 +1,138 @@
+/* eslint-disable no-console */
+import React, { useCallback, useEffect, useMemo, useReducer } from 'react'
+
+import { useWallet } from '../../hooks/useWallet/useWallet'
+import { KeyManager } from '../WalletProvider/KeyManager'
+import { getLocalWalletDeviceId, getLocalWalletType } from '../WalletProvider/local-wallet'
+import { ActionTypes, XDEFIProviderActions } from './actions'
+import { InitialState, IXfiBitcoinProvider, IXfiLitecoinProvider } from './types'
+import { IXDEFIProviderContext, XDEFIProviderContext } from './XDEFIContext'
+
+const initialState: InitialState = {
+  ethereumWallet: null,
+  xfiBitcoinProvider: null,
+  xfiLitecoinProvider: null,
+  isWalletLoading: false,
+}
+
+export const reducer = (state: InitialState, action: ActionTypes) => {
+  switch (action.type) {
+    case XDEFIProviderActions.XDEFI_CONNECTED: {
+      return {
+        ...state,
+        ...action.payload,
+        isWalletLoading: false,
+      }
+    }
+    case XDEFIProviderActions.XDEFI_NOT_CONNECTED: {
+      return {
+        ...initialState,
+        ...action.payload,
+        isWalletLoading: false,
+      }
+    }
+    case XDEFIProviderActions.RESET_STATE: {
+      return {
+        ...initialState,
+        isWalletLoading: false,
+      }
+    }
+    default:
+      return state
+  }
+}
+
+const getInitialState = () => {
+  const localWalletType = getLocalWalletType()
+  const localWalletDeviceId = getLocalWalletDeviceId()
+  if (localWalletType && localWalletDeviceId) {
+    return {
+      ...initialState,
+      isWalletLoading: true,
+    }
+  }
+  return initialState
+}
+
+const injectedAccount = async (
+  xfiProvider: IXfiBitcoinProvider | IXfiLitecoinProvider,
+): Promise<string[]> => {
+  return new Promise(resolve => {
+    xfiProvider.request(
+      { method: 'request_accounts', params: [] },
+      (error: any, accounts: string[]) => {
+        if (!error && accounts.length) {
+          resolve(accounts)
+        }
+        if (error) {
+          resolve([])
+        }
+      },
+    )
+  })
+}
+
+export const XDEFIWalletProvider = ({ children }: { children: React.ReactNode }): JSX.Element => {
+  const [state, dispatch] = useReducer(reducer, getInitialState())
+  const {
+    state: { wallet },
+  } = useWallet()
+  const localWalletType = getLocalWalletType()
+  const localWalletDeviceId = getLocalWalletDeviceId()
+
+  const load = useCallback(() => {
+    if (localWalletType && localWalletDeviceId) {
+      switch (localWalletType) {
+        case KeyManager.XDefi: {
+          ;(async () => {
+            const xfi = (window as any).xfi
+            const xfiBitcoinProvider: IXfiBitcoinProvider = xfi['bitcoin']
+            const xfiLitecoinProvider: IXfiLitecoinProvider = xfi['litecoin']
+            const xfiBitcoinAccounts = await injectedAccount(xfiBitcoinProvider)
+            const xfiLItecoinAccounts = await injectedAccount(xfiLitecoinProvider)
+
+            dispatch({
+              type: XDEFIProviderActions.XDEFI_CONNECTED,
+              payload: {
+                ethereumWallet: wallet!,
+                xfiBitcoinProvider: {
+                  ...xfiBitcoinProvider,
+                  accounts: xfiBitcoinAccounts,
+                },
+                xfiLitecoinProvider: {
+                  ...xfiLitecoinProvider,
+                  accounts: xfiLItecoinAccounts,
+                },
+              },
+            })
+          })()
+          break
+        }
+        default: {
+          dispatch({
+            type: XDEFIProviderActions.XDEFI_NOT_CONNECTED,
+            payload: {
+              ethereumWallet: wallet!,
+            },
+          })
+        }
+      }
+    } else {
+      dispatch({
+        type: XDEFIProviderActions.RESET_STATE,
+      })
+    }
+  }, [localWalletType, localWalletDeviceId, wallet])
+
+  useEffect(() => load(), [load])
+
+  const value: IXDEFIProviderContext = useMemo(
+    () => ({
+      state,
+      dispatch,
+    }),
+    [state],
+  )
+
+  return <XDEFIProviderContext.Provider value={value}>{children}</XDEFIProviderContext.Provider>
+}

--- a/src/context/XDEFIProvider/actions.ts
+++ b/src/context/XDEFIProvider/actions.ts
@@ -1,0 +1,28 @@
+import { HDWallet } from '@shapeshiftoss/hdwallet-core'
+
+import { IXfiBitcoinProvider, IXfiLitecoinProvider } from './types'
+
+export enum XDEFIProviderActions {
+  XDEFI_CONNECTED = 'XDEFI_CONNECTED',
+  XDEFI_NOT_CONNECTED = 'XDEFI_NOT_CONNECTED',
+  RESET_STATE = 'RESET_STATE',
+}
+
+export type ActionTypes =
+  | {
+      type: XDEFIProviderActions.XDEFI_CONNECTED
+      payload: {
+        ethereumWallet: HDWallet
+        xfiBitcoinProvider: IXfiBitcoinProvider
+        xfiLitecoinProvider: IXfiLitecoinProvider
+      }
+    }
+  | {
+      type: XDEFIProviderActions.XDEFI_NOT_CONNECTED
+      payload: {
+        ethereumWallet: HDWallet
+      }
+    }
+  | {
+      type: XDEFIProviderActions.RESET_STATE
+    }

--- a/src/context/XDEFIProvider/hooks/useXDEFIProvider.ts
+++ b/src/context/XDEFIProvider/hooks/useXDEFIProvider.ts
@@ -1,0 +1,6 @@
+import { useContext } from 'react'
+
+import { IXDEFIProviderContext, XDEFIProviderContext } from '../XDEFIContext'
+
+export const useXDEFIProvider = (): IXDEFIProviderContext =>
+  useContext(XDEFIProviderContext as React.Context<IXDEFIProviderContext>)

--- a/src/context/XDEFIProvider/types.ts
+++ b/src/context/XDEFIProvider/types.ts
@@ -1,0 +1,27 @@
+import { HDWallet } from '@shapeshiftoss/hdwallet-core'
+
+import { AnyFunction } from '../../types/common'
+
+export interface InitialState {
+  ethereumWallet: HDWallet | null
+  xfiBitcoinProvider: IXfiBitcoinProvider | null
+  xfiLitecoinProvider: IXfiLitecoinProvider | null
+  isWalletLoading: boolean
+}
+
+export interface IXfiBitcoinProvider {
+  accounts: string[]
+  chainId: string
+  network: string
+  request: (e: { method: string; params: any[] }, cb: AnyFunction) => Promise<any>
+  signTransaction: (e: any) => Promise<void>
+  transfer: (e: any) => Promise<void>
+}
+
+export interface IXfiLitecoinProvider {
+  accounts: string[]
+  chainId: string
+  network: string
+  request: (e: { method: string; params: any[] }, cb: AnyFunction) => void
+  transfer: (e: any) => void
+}


### PR DESCRIPTION
## Overview

Creates a context wrapper that exposes xdefi bitcoin and litecoin providers when xdefi wallet is connected.

## Notes

There are three states that this provider will be in

### XDEFI_CONNECTED

Xdefi wallet is propoerly connected.

returned state

```
ethereumWallet: HDWallet
xfiBitcoinProvider: IXfiBitcoinProvider
xfiLitecoinProvider: IXfiLitecoinProvider
```

### XDEFI_NOT_CONNECTED

A different wallet is connected. in this case the ethereum wallet is set leaving `bitcoin` and `litecoin` providers `null`

```
ethereumWallet: HDWallet
xfiBitcoinProvider: null
xfiLitecoinProvider: null
```

### NOT_CONNECTED

No Wallet is connected (default state)

```
ethereumWallet: null,
xfiBitcoinProvider: null,
xfiLitecoinProvider: null,
```

## USUAGE

import the Provider component and wrap

```
import { XDEFIWalletProvider } from 'context/XDEFIProvider/XDEFIWalletProvider'

function Component() {
  return (
    <XDEFIWalletProvider>
      <ChildComponent>
    </XDEFIWalletProvider>
  )
}
```

and easily use the custom hook in children

```
import { useXdefiProvider } from 'context/XDEFIProvider/hooks/useXDEFIProvider'

function ChildComponent() {
  const {
    state: { xfiBitcoinProvider, xfiLitecoinProvider, ethereumWallet, isWalletLoading },
  } = useXDEFIProvider()


  return (
    ...
  )
}
```